### PR TITLE
[Tech] CI baseline: README-only touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Error message: PKCS#12 MAC could not be verified. Invalid password?
 
 > Pour l’erreur DESIR_560 - Niveau d'accès insuffisant : Si le CN de votre certificat Client est différent INSI-MANU ou INSI-AUTO, le serveur renvoi une erreur DESIR_560 avec le message « Vous ne disposez pas des droits suffisants pour accéder à ce service ». Le CN doit être égale à INSI-MANU ou INSI-AUTO et tous les caractères doivent être en majuscule et le séparateur entre INIS et AUTO est un signe moins -
 > Pour vérifier le serveur du serveur, vous devez utiliser les AC « AC IGC-SANTE ELEMENTAIRE ORGANISATIONS » et AC RACINE IGC-SANTE ELEMENTAIRE. Ces 2 fichier d'AC sont disponibles à cette adresse : http://igc-sante.esante.gouv.fr/PC/
+
+<!-- CI baseline test 1779271061 -->


### PR DESCRIPTION
Touches only README.md. No code, no deps. Used to verify whether `Run INS Tests` / `Run Medimail Tests` failures on PR #49 are pre-existing external-infra issues (independent of dep bumps) or caused by the bumps themselves.