### PR TITLE
[Security] Bump node-forge to ^1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@padoa/tlsi-ins",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@padoa/tlsi-ins",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.0.3",
         "lodash": "^4.18.0",
-        "node-forge": "~1.3.2",
+        "node-forge": "^1.4.0",
         "soap": "^1.1.11",
         "uuid": "^9.0.0",
         "xml-crypto": "^2.1.6"
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.1",
         "@types/lodash": "^4.14.181",
-        "@types/node-forge": "^1.3.2",
+        "@types/node-forge": "^1.3.11",
         "@types/uuid": "^9.0.1",
         "@types/xml-crypto": "^1.4.2",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
@@ -2006,10 +2006,11 @@
       "dev": true
     },
     "node_modules/@types/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-TzX3ahoi9xbmaoT58smrBu7oa6dQXb/+PTNCslZyD/55tlJ/osofIMClzZsoo6buDFrg7e4DvVGkZqVgv6OLxw==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -5528,9 +5529,9 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -8093,9 +8094,9 @@
       "dev": true
     },
     "@types/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-TzX3ahoi9xbmaoT58smrBu7oa6dQXb/+PTNCslZyD/55tlJ/osofIMClzZsoo6buDFrg7e4DvVGkZqVgv6OLxw==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -10712,9 +10713,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Access the Téléservice Identité Nationale de Santé & Medimail MSSanté API with a js API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "scripts": {
     "build": "rm -rf dist && npm run clean && tsc && mkdir -p dist/wsdl && cp -r src/wsdl/* dist/wsdl/",
     "clean": "tsc --build --clean",
@@ -35,7 +35,7 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "lodash": "^4.18.0",
-    "node-forge": "~1.3.2",
+    "node-forge": "^1.4.0",
     "soap": "^1.1.11",
     "uuid": "^9.0.0",
     "xml-crypto": "^2.1.6"
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.1",
     "@types/lodash": "^4.14.181",
-    "@types/node-forge": "^1.3.2",
+    "@types/node-forge": "^1.3.11",
     "@types/uuid": "^9.0.1",
     "@types/xml-crypto": "^1.4.2",
     "@typescript-eslint/eslint-plugin": "^6.12.0",


### PR DESCRIPTION
Sysdig critical vulnerability in node-forge 1.3.x. Bump range so medical/back-dist image resolves 1.4.0.